### PR TITLE
Fix viewerCount parameter being a String on Twitch raid event

### DIFF
--- a/TwitchService_IRC.gd
+++ b/TwitchService_IRC.gd
@@ -155,7 +155,7 @@ func irc_inject_packet(packet_text):
 							"handle_channel_raid",
 							parsed_message["tags"]["msg-param-login"],
 							parsed_message["tags"]["msg-param-displayName"],
-							parsed_message["tags"]["msg-param-viewerCount"])
+							parsed_message["tags"]["msg-param-viewerCount"].to_int())
 
 			# Handle incoming messages, including bit cheers.
 			if parsed_message["command"].to_lower() == "privmsg":


### PR DESCRIPTION
It appears that when parsing the parameters from an IRC raid event, the viewerCount parameter is simple passed on as a `String` rather than being converted to an `int` beforehand.

I noticed this issue because I was using typed functions, and Godot complained at me with the following error:

```
E 0:12:41:267   TwitchService_IRC.gd:154 @ irc_inject_packet(): Error calling from signal 'handle_channel_raid' to callable: 'Node(TwitchChatManager.gd)::_on_channel_raid': Cannot convert argument 3 from String to int.
  <C++ Source>  core/object/object.cpp:1249 @ emit_signalp()
  <Stack Trace> TwitchService_IRC.gd:154 @ irc_inject_packet()
                TwitchService_IRC.gd:131 @ _client_irc_handle_data_received()
                TwitchService_IRC.gd:219 @ _client_irc_update()
                TwitchService.gd:248 @ _process()
```

Fixed by simply using `.to_int()` on the parameter.

This could cause issues with people using the addon in existing code, expecting the viewer count to be a string.

(Converting to typed GDScript might be a good idea in general.)